### PR TITLE
fix(ci): correct bundled VSIX version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.2",
+        "@semantic-release/npm": "^13.1.3",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "boardlab",
   "displayName": "BoardLab",
   "version": "0.0.2",
+  "private": true,
   "description": "Vendor-independent board development for Visual Studio Code, powered by Arduino CLI.",
   "categories": [
     "Programming Languages",
@@ -1539,6 +1540,7 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.2",
+    "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",

--- a/release.config.js
+++ b/release.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
+    '@semantic-release/npm',
     [
       '@semantic-release/github',
       {


### PR DESCRIPTION
 - semantic-release must run npm to bump the version for the final VSIX