### PR TITLE
fix: omit missing baud rate from send placeholder

### DIFF
--- a/packages/webviews/monitor-shared/src/serial-monitor/MonitorSendBar.jsx
+++ b/packages/webviews/monitor-shared/src/serial-monitor/MonitorSendBar.jsx
@@ -72,7 +72,7 @@ function MonitorSendBar({ client, lineEnding }) {
   })()
 
   let sendPlaceholder = selectedPort
-    ? `Message (Enter to send; append ${lineEndingDescription}, ${selectedPort.address}, baudrate: ${selectedBaudrate})`
+    ? `Message (Enter to send; append ${lineEndingDescription}, ${selectedPort.address}${selectedBaudrate ? `, baudrate: ${selectedBaudrate}` : ''})`
     : 'Select a port to send'
 
   let sendDisabled = !selectedPort

--- a/packages/webviews/monitor/src/features/app/MonitorSendBar.test.jsx
+++ b/packages/webviews/monitor/src/features/app/MonitorSendBar.test.jsx
@@ -136,6 +136,35 @@ describe('MonitorSendBar', () => {
     expect(pointerEventsOf(sendIcon)).not.toBe('none')
   })
 
+  it('omits the baudrate for ports without baudrate support', () => {
+    const port = {
+      protocol: 'teensy',
+      address: 'usb:1000000',
+    }
+    const portKey = createPortKey(port)
+    const placeholder = 'Message (Enter to send; append LF, usb:1000000)'
+
+    withSerialMonitorState({
+      selectedPort: port,
+      selectedBaudrates: [],
+      detectedPorts: {
+        [portKey]: { port },
+      },
+      sessionStates: {
+        [portKey]: makeSessionState({
+          portKey,
+          port,
+          status: 'active',
+          desired: 'running',
+          lastCompletedAttemptId: 1,
+        }),
+      },
+    })
+
+    const textarea = screen.getByPlaceholderText(placeholder)
+    expect(textarea).toHaveAttribute('placeholder', placeholder)
+  })
+
   it('shows suspended UI while started and waiting for device', () => {
     vi.useFakeTimers()
     withSerialMonitorState({


### PR DESCRIPTION
## Summary

Avoid rendering the literal word undefined when a selected serial port has no baud rate.

## Change

- `packages/webviews/monitor-shared/src/serial-monitor/MonitorSendBar.jsx`
- `packages/webviews/monitor/src/features/app/MonitorSendBar.test.jsx`

### Checks
- `NODE_OPTIONS="--import=data:text/javascript,globalThis.__dirname=process.cwd()" npm --prefix packages/webviews/monitor test -- --configLoader runner --run src/features/app/MonitorSendBar.test.jsx` — passed in a network-isolated container.

Fixes #26

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-160:start -->
### Verification

[Northset proof-of-pass receipt M-160](https://northset-oss.github.io/verification-pilot/receipts/M-160/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-160:end -->
